### PR TITLE
Easier to clone over HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ well you are sticking with your daily or weekly habits.
 
 ## Installation
 ```commandline
-$ git clone git@github.com:ohtyap/habit-tracker.git
+$ git clone https://github.com/ohtyap/habit-tracker
 $ cd habit-tracker
 $ python -m habits
 ```


### PR DESCRIPTION
I'm trying your habit tracker, looks like exactly what I'm looking for.

Noticed while doing it in the install section the clone over ssh, which needs a github account. It's easier for users to clone using https : they don't need to login, they don't even need a github account.

While I'm here, why are the issue closed in this repo?